### PR TITLE
LWRP idempotence

### DIFF
--- a/providers/param.rb
+++ b/providers/param.rb
@@ -14,7 +14,8 @@ action :apply do
     m[o] ||= {}
     m[o]
   end
-  unless location[key_path.last] == new_resource.value
+  value_as_string = Sysctl.compile_attr('', new_resource.value).to_s.sub(/^=/,'')
+  unless location[key_path.last] == new_resource.value || location[key_path.last] == value_as_string
     location[key_path.last] = new_resource.value
     node.default['sysctl']['params'] = sys_attrs
     execute "sysctl[#{new_resource.key}]" do

--- a/providers/param.rb
+++ b/providers/param.rb
@@ -14,7 +14,7 @@ action :apply do
     m[o] ||= {}
     m[o]
   end
-  value_as_string = Sysctl.compile_attr('', new_resource.value).to_s.sub(/^=/,'')
+  value_as_string = Sysctl.compile_attr('', new_resource.value).to_s.sub(/^=/, '')
   unless location[key_path.last] == new_resource.value || location[key_path.last] == value_as_string
     location[key_path.last] = new_resource.value
     node.default['sysctl']['params'] = sys_attrs

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -35,7 +35,7 @@ sysctl_config_file = Sysctl.config_file(node)
 if sysctl_config_file
   # If default sysctl.params attributes are not set, set them at recipe compile time
   # to the values output by the last run. This allows the LWRPs to act idempotently
-  if File.exists?(sysctl_config_file)
+  if File.exist?(sysctl_config_file)
     File.read(sysctl_config_file).lines.each do |l|
       next unless l =~ /^[\w\.]+?=/
       key, val = l.chomp.split('=')
@@ -48,7 +48,6 @@ if sysctl_config_file
     end
   end
 
-  
   # this is called by the sysctl_param lwrp to trigger template creation
   ruby_block 'save-sysctl-params' do
     action :nothing


### PR DESCRIPTION
I am sad that this cookbook has been skewing my resources-executed numbers but we tend to prefer resources to attribute-loops

I did my best not interfere with mixed use of params and LWRPs (if that's a thing) / be as backwards compatible as possible

Notably, one can paste the first commit's added block (default.rb L38-49) in front of `include_recipe 'sysctl::default'` as a workaround with the current released version of this cookbook