### PR TITLE
Suse 11 & 12 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ group :unit do
   gem 'foodcritic',       '~> 5.0'
   gem 'rubocop',          '~> 0.36', '>= 0.36.0'
   gem 'chefspec',         '~> 4.5.0'
+  gem 'serverspec',       '~> 2.21'
 end
 
 group :integration do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,41 @@ GEM
       serverspec (~> 2.7)
       specinfra (~> 2.10)
       syslog-logger (~> 1.6)
+    chef (12.6.0-universal-mingw32)
+      chef-config (= 12.6.0)
+      chef-zero (~> 4.2, >= 4.2.2)
+      diff-lcs (~> 1.2, >= 1.2.4)
+      erubis (~> 2.7)
+      ffi (~> 1.9)
+      ffi-yajl (~> 2.2)
+      highline (~> 1.6, >= 1.6.9)
+      mixlib-authentication (~> 1.3)
+      mixlib-cli (~> 1.4)
+      mixlib-log (~> 1.3)
+      mixlib-shellout (~> 2.0)
+      net-ssh (~> 2.6)
+      net-ssh-multi (~> 1.1)
+      ohai (>= 8.6.0.alpha.1, < 9)
+      plist (~> 3.1.0)
+      proxifier (~> 1.0)
+      pry (~> 0.9)
+      rspec-core (~> 3.4)
+      rspec-expectations (~> 3.4)
+      rspec-mocks (~> 3.4)
+      rspec_junit_formatter (~> 0.2.0)
+      serverspec (~> 2.7)
+      specinfra (~> 2.10)
+      syslog-logger (~> 1.6)
+      win32-api (~> 1.5.3)
+      win32-dir (~> 0.5.0)
+      win32-event (~> 0.6.1)
+      win32-eventlog (= 0.6.3)
+      win32-mmap (~> 0.4.1)
+      win32-mutex (~> 0.4.2)
+      win32-process (~> 0.8.2)
+      win32-service (~> 0.8.7)
+      windows-api (~> 0.4.4)
+      wmi-lite (~> 1.0)
     chef-config (12.6.0)
       mixlib-config (~> 2.0)
       mixlib-shellout (~> 2.0)
@@ -115,6 +150,7 @@ GEM
     fauxhai (3.1.0)
       net-ssh
     ffi (1.9.10)
+    ffi (1.9.10-x86-mingw32)
     ffi-yajl (2.2.3)
       libyajl2 (~> 1.2)
     foodcritic (5.0.0)
@@ -127,6 +163,8 @@ GEM
       yajl-ruby (~> 1.1)
     formatador (0.2.5)
     gherkin (2.12.2)
+      multi_json (~> 1.3)
+    gherkin (2.12.2-x86-mingw32)
       multi_json (~> 1.3)
     guard (2.13.0)
       formatador (>= 0.2.4)
@@ -155,6 +193,7 @@ GEM
     hashie (3.4.3)
     highline (1.7.8)
     hitimes (1.2.3)
+    hitimes (1.2.3-x86-mingw32)
     httpclient (2.6.0.1)
     i18n (0.7.0)
     ice_nine (0.11.1)
@@ -191,6 +230,9 @@ GEM
     mixlib-install (0.7.1)
     mixlib-log (1.6.0)
     mixlib-shellout (2.2.5)
+    mixlib-shellout (2.2.5-universal-mingw32)
+      win32-process (~> 0.8.2)
+      wmi-lite (~> 1.0)
     multi_json (1.11.2)
     multipart-post (2.0.0)
     nenv (0.2.0)
@@ -205,6 +247,8 @@ GEM
     net-telnet (0.1.1)
     nio4r (1.2.0)
     nokogiri (1.6.7.2)
+      mini_portile2 (~> 2.0.0.rc2)
+    nokogiri (1.6.7.2-x86-mingw32)
       mini_portile2 (~> 2.0.0.rc2)
     notiffany (0.0.8)
       nenv (~> 0.1)
@@ -337,11 +381,34 @@ GEM
       coercible (~> 1.0)
       descendants_tracker (~> 0.0, >= 0.0.3)
       equalizer (~> 0.0, >= 0.0.9)
+    wdm (0.1.1)
+    win32-api (1.5.3-universal-mingw32)
+    win32-dir (0.5.1)
+      ffi (>= 1.0.0)
+    win32-event (0.6.3)
+      win32-ipc (>= 0.6.0)
+    win32-eventlog (0.6.3)
+      ffi
+    win32-ipc (0.6.6)
+      ffi
+    win32-mmap (0.4.2)
+      ffi
+    win32-mutex (0.4.3)
+      win32-ipc (>= 0.6.0)
+    win32-process (0.8.3)
+      ffi (>= 1.0.0)
+    win32-service (0.8.7)
+      ffi
+    win32console (1.3.2)
+    win32console (1.3.2-x86-mingw32)
+    windows-api (0.4.4)
+      win32-api (>= 1.4.5)
     wmi-lite (1.0.0)
     yajl-ruby (1.2.1)
 
 PLATFORMS
   ruby
+  x86-mingw32
 
 DEPENDENCIES
   berkshelf (~> 4.0.1)
@@ -360,8 +427,11 @@ DEPENDENCIES
   rspec_junit_formatter
   rubocop (~> 0.36, >= 0.36.0)
   rubocop-checkstyle_formatter
+  serverspec (~> 2.21)
   terminal-notifier-guard
   test-kitchen (~> 1.5)
+  wdm (>= 0.1.1)
+  win32console
 
 BUNDLED WITH
    1.10.6

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -32,3 +32,13 @@ if platform_family?('arch', 'debian', 'rhel', 'fedora')
 else
   default['sysctl']['conf_dir'] = nil
 end
+
+if platform_family?('suse')
+  if node['platform_version'].to_f < 12.0
+    default['sysctl']['allow_sysctl_conf'] = true
+    default['sysctl']['conf_file'] = '/etc/sysctl.conf'
+  else
+    default['sysctl']['conf_dir'] = '/etc/sysctl.d'
+    default['sysctl']['conf_file'] = File.join(node['sysctl']['conf_dir'], '/99-chef-attributes.conf')
+  end
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,7 +21,8 @@
 
 include_recipe 'sysctl::service'
 
-directory node['sysctl']['conf_dir'] do
+directory 'Sysctl config directory' do
+  path node['sysctl']['conf_dir']
   owner 'root'
   group 'root'
   mode 0755

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -52,7 +52,7 @@ service 'procps' do
     if node['platform_version'].to_f < 12.0
       supports :restart => false, :reload => false, :status => true
       service_name 'boot.sysctl'
-    else node['platform_version'].to_f >= 12.0
+    elsif node['platform_version'].to_f >= 12.0
       service_name 'systemd-sysctl'
       provider Chef::Provider::Service::Systemd
     end

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -48,6 +48,14 @@ service 'procps' do
     elsif node['platform_version'].to_f >= 15.04
       provider Chef::Provider::Service::Init::Systemd
     end
+  when 'suse'
+    if node['platform_version'].to_f < 12.0
+      supports :restart => false, :reload => false, :status => true
+      service_name 'boot.sysctl'
+    else node['platform_version'].to_f >= 12.0
+      service_name 'systemd-sysctl'
+      provider Chef::Provider::Service::Systemd
+    end
   end
   action :enable
 end

--- a/spec/apply_spec.rb
+++ b/spec/apply_spec.rb
@@ -9,7 +9,8 @@ describe 'sysctl::apply' do
     'fedora' => %w(18 20),
     'redhat' => ['6.5', '7.0'],
     'centos' => ['6.5', '7.0'],
-    'freebsd' => ['9.2']
+    'freebsd' => ['9.2'],
+    'suse' => ['11.2', '12.0']
   }
 
   # Test all generic stuff on all platforms

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -9,7 +9,8 @@ describe 'sysctl::default' do
     'fedora' => %w(18 20),
     'redhat' => ['6.5', '7.0'],
     'centos' => ['6.5', '7.0'],
-    'freebsd' => ['9.2']
+    'freebsd' => ['9.2'],
+    'suse' => ['11.2', '12.0']
   }
 
   # Test all generic stuff on all platforms
@@ -51,6 +52,8 @@ describe 'sysctl::default' do
         let(:template) do
           if platform == 'freebsd'
             chef_run.template('/etc/sysctl.conf.local')
+          elsif platform == 'suse' && version.to_f < 12.0
+            chef_run.template('/etc/sysctl.conf')
           else
             chef_run.template('/etc/sysctl.d/99-chef-attributes.conf')
           end

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -9,7 +9,8 @@ describe 'sysctl::service' do
     'fedora' => %w(18 20),
     'redhat' => ['6.5', '7.0'],
     'centos' => ['6.5', '7.0'],
-    'freebsd' => ['9.2']
+    'freebsd' => ['9.2'],
+    'suse' => ['11.2', '12.0']
   }
 
   # Test all generic stuff on all platforms

--- a/test/integration/attributes/serverspec/attrs_spec.rb
+++ b/test/integration/attributes/serverspec/attrs_spec.rb
@@ -17,6 +17,10 @@ persistence_file = case os[:family].downcase
                      '/etc/sysctl.conf'
                    end
 
+if os[:family] == 'suse' && host_inventory['platform_version'].to_f >= 12.0
+  persistence_file = '/etc/sysctl.d/99-chef-attributes.conf'
+end
+
 describe file(persistence_file) do
   it { should be_file }
   it { should contain 'vm.swappiness=19' }

--- a/test/integration/default/serverspec/attrs_spec.rb
+++ b/test/integration/default/serverspec/attrs_spec.rb
@@ -17,6 +17,10 @@ persistence_file = case os[:family].downcase
                      '/etc/sysctl.conf'
                    end
 
+if os[:family] == 'suse' && host_inventory['platform_version'].to_f >= 12.0
+  persistence_file = '/etc/sysctl.d/99-chef-attributes.conf'
+end
+
 describe file(persistence_file) do
   it { should be_file }
   it { should contain 'vm.swappiness=19' }

--- a/test/integration/default/serverspec/lwrps_spec.rb
+++ b/test/integration/default/serverspec/lwrps_spec.rb
@@ -17,6 +17,10 @@ persistence_file = case os[:family].downcase
                      '/etc/sysctl.conf'
                    end
 
+if os[:family] == 'suse' && host_inventory['platform_version'].to_f >= 12.0
+  persistence_file = '/etc/sysctl.d/99-chef-attributes.conf'
+end
+
 describe file(persistence_file) do
   it { should be_file }
   it { should contain 'net.ipv4.tcp_max_syn_backlog=12345' }

--- a/test/integration/lwrps/serverspec/lwrps_spec.rb
+++ b/test/integration/lwrps/serverspec/lwrps_spec.rb
@@ -17,6 +17,10 @@ persistence_file = case os[:family].downcase
                      '/etc/sysctl.conf'
                    end
 
+if os[:family] == 'suse' && host_inventory['platform_version'].to_f >= 12.0
+  persistence_file = '/etc/sysctl.d/99-chef-attributes.conf'
+end
+
 describe file(persistence_file) do
   it { should be_file }
   it { should contain 'net.ipv4.tcp_max_syn_backlog=12345' }


### PR DESCRIPTION
This provides support for Suse Enterprise Linux 11 and 12 (tested on 11 SP2 and 12). Due to license restrictions I cannot provide images to test with in test-kitchen, but I have updated the chefspec tests (fauxhai has support for Suse) to at least provide some level of testing. For those with access to install media and wanting to test, I built the images using the definitions found in the Bento project (http://www.github.com/chef/bento).

Fixes #32

All tests pass with the exception of FreeBSD 9.2 (unknown oid on sysctl command) and Arch (fails on chef install) which is consistent with the current state of master. 