### PR TITLE
Set SYSTEMCTL_SKIP_REDIRECT=1 in RHEL init script

### DIFF
--- a/templates/default/procps.init-rhel.erb
+++ b/templates/default/procps.init-rhel.erb
@@ -7,6 +7,7 @@
 # this was installed by the sysctl cookbook
 # https://supermarket.chef.io/cookbooks/sysctl
 
+SYSTEMCTL_SKIP_REDIRECT=1
 
 # Source function library.
 . /etc/rc.d/init.d/functions


### PR DESCRIPTION
On CentOS 7.1 it does not work as expected. This is hack but solves the problem.