### PR TITLE
Systemd fixes for modern RHEL-like distros

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -54,6 +54,6 @@ if Sysctl.config_file(node)
     action :nothing
     source 'sysctl.conf.erb'
     mode '0644'
-    notifies :start, 'service[procps]', :immediately
+    notifies :restart, 'service[procps]', :immediately
   end
 end

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -31,6 +31,16 @@ service 'procps' do
   when 'arch', 'exherbo'
     service_name 'systemd-sysctl'
     provider Chef::Provider::Service::Systemd
+  when 'centos', 'redhat', 'scientific', 'amazon'
+    if node['platform_version'].to_f >= 7.0
+      service_name 'systemd-sysctl'
+      provider Chef::Provider::Service::Systemd
+    end
+  when 'fedora'
+    if node['platform_version'].to_f >= 18
+      service_name 'systemd-sysctl'
+      provider Chef::Provider::Service::Systemd
+    end
   when 'ubuntu'
     if node['platform_version'].to_f >= 9.10 && node['platform_version'].to_f < 15.04
       service_name 'procps-instance' if node['platform_version'].to_f >= 14.10

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -62,8 +62,8 @@ describe 'sysctl::default' do
         end
 
         it 'sends the specific notification to the procps service immediately' do
-          expect(template).to notify('service[procps]').to(:start).immediately
-          expect(template).to_not notify('service[procps]').to(:start).delayed
+          expect(template).to notify('service[procps]').to(:restart).immediately
+          expect(template).to_not notify('service[procps]').to(:restart).delayed
         end
       end
     end


### PR DESCRIPTION
This PR is basically a cleaned up version of this existing PR: https://github.com/svanzoest-cookbooks/sysctl/pull/15

This fixes sysctl attributes not getting reapplied when they are changed on RHEL/CentOS/Fedora versions that use systemd.