### PR TITLE
Version pin the Ohai cookbook.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -16,4 +16,4 @@ supports 'scientific', '>= 6.4'
 end
 conflicts 'jn_sysctl'
 conflicts 'el-sysctl'
-depends 'ohai'
+depends 'ohai', '~> 2.1'


### PR DESCRIPTION
Chef today released version 3.0.0 of the Ohai cookbook, which makes breaking changes to users of Chefspec. The sysctl cookbook does not version pin the Ohai cookbook, and allows any version of Ohai to be picked up.

I've version-pinned Ohai in this cookbook to be ~> 2.1, which is the version defined in its Berksfile.lock. At minimum, this would mitigate a breaking change to Ohai (really a major version change) from being automatically picked up by cookbooks inheriting the sysctl cookbook. Users could then version-pin sysctl directly, rather than somewhat awkwardly version-pinning Ohai despite it not being a direct dependency, prior to sysctl being updated to reflect support for newer versions of Ohai.