### PR TITLE
Guard clause instead of nest ifs; make defaults explicit (resolve Rubocop finding)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,7 @@ namespace :style do
   FoodCritic::Rake::LintTask.new(:chef) do |t|
     t.options = {
       fail_tags: ['any'],
-      tags: []
+      tags: %w(~FC007 ~FC015 ~FC023)
     }
   end
 end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,20 +17,18 @@
 # limitations under the License.
 #
 default['sysctl']['params'] = {}
+default['sysctl']['allow_sysctl_conf'] = false
+default['sysctl']['conf_file'] = '/etc/sysctl.conf'
+default['sysctl']['conf_dir'] = nil
 
 if platform_family?('freebsd')
   default['sysctl']['allow_sysctl_conf'] = true
   default['sysctl']['conf_file'] = '/etc/sysctl.conf.local'
-else
-  default['sysctl']['allow_sysctl_conf'] = false
-  default['sysctl']['conf_file'] = '/etc/sysctl.conf'
 end
 
 if platform_family?('arch', 'debian', 'rhel', 'fedora')
   default['sysctl']['conf_dir'] = '/etc/sysctl.d'
   default['sysctl']['conf_file'] = File.join(node['sysctl']['conf_dir'], '/99-chef-attributes.conf')
-else
-  default['sysctl']['conf_dir'] = nil
 end
 
 if platform_family?('suse')

--- a/libraries/sysctl.rb
+++ b/libraries/sysctl.rb
@@ -2,15 +2,9 @@
 module Sysctl
   class << self
     def config_file(node)
-      if node['sysctl']['conf_dir']
-        return node['sysctl']['conf_file']
-      else
-        if node['sysctl']['allow_sysctl_conf']
-          return node['sysctl']['conf_file']
-        else
-          return nil
-        end
-      end
+      return nil unless node['sysctl']['conf_dir'] || node['sysctl']['allow_sysctl_conf']
+
+      node['sysctl']['conf_file']
     end
 
     def compile_attr(prefix, v)


### PR DESCRIPTION
Make the build badge green!

* Copied the list of turned off foodcritic rules to the rake task
* refactored `config_file()` to have a `return nil` guard clause instead of nested ifs (this resolves the Rubocop finding)
* rolled the attribute assignments that lived in `else` blocks up to make it clear that they are the defaults, leaving the platform-specific assignments in-place in the `if` blocks to overwrite defaults