### PR TITLE
Allow newer versions of ohai

### DIFF
--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -10,8 +10,8 @@ DEPENDENCIES
 GRAPH
   apt (3.0.0)
   ohai (3.0.1)
-  sysctl (0.7.3)
-    ohai (~> 3.0)
+  sysctl (0.7.6)
+    ohai (>= 3.0.0)
   sysctl_test (0.1.0)
     sysctl (>= 0.0.0)
   yum (3.10.0)

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ source_url 'https://github.com/svanzoest-cookbooks/sysctl/' if respond_to?(:sour
 license 'Apache v2.0'
 description 'Configures sysctl parameters'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.7.5'
+version '0.7.6'
 supports 'ubuntu', '>= 12.04'
 supports 'debian', '>= 7.0'
 supports 'centos', '>= 5.9'
@@ -17,4 +17,4 @@ supports 'suse', '>= 11.0'
 end
 conflicts 'jn_sysctl'
 conflicts 'el-sysctl'
-depends 'ohai', '~> 3.0'
+depends 'ohai', '>= 3.0'


### PR DESCRIPTION
Allows for the use of a newer version of the ohai cookbook than 3.0 which will allow this cookbook to be used in conjunction with other cookbooks relying on newer versions of ohai.