### PR TITLE
Use systemd-sysctl for service name on Ubuntu 15+

### DIFF
--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -46,6 +46,7 @@ service 'procps' do
       service_name 'procps-instance' if node['platform_version'].to_f >= 14.10
       provider Chef::Provider::Service::Upstart
     elsif node['platform_version'].to_f >= 15.04
+      service_name 'systemd-sysctl'
       provider Chef::Provider::Service::Init::Systemd
     end
   when 'suse'


### PR DESCRIPTION
Like all the other distros using systemd, Ubuntu's service for sysctl is systemd-sysctl.